### PR TITLE
Fixed a eager regexp that was causing erroneous strong results

### DIFF
--- a/creole.el
+++ b/creole.el
@@ -1098,6 +1098,10 @@ Returns the HTML-BUFFER."
                    (insert (format "<h2>%s</h2>\n" (cdr element))))
                   (heading3
                    (insert (format "<h3>%s</h3>\n" (cdr element))))
+                  (heading4
+                   (insert (format "<h4>%s</h4>\n" (cdr element))))
+                  (heading5
+                   (insert (format "<h5>%s</h5>\n" (cdr element))))
                   ;; Tables
                   (table
                    (insert (creole--html-table (cdr element))))

--- a/creole.el
+++ b/creole.el
@@ -54,7 +54,7 @@ In the future we need to have some sort of resolution system here?
 Possibly it would be good to orthongonaly update some list of
 links."
   (replace-regexp-in-string
-   "\\[\\[\\(\\([A-Za-z]+:\\)*[^|]+\\)\\(|\\(\\([^]]+\\)\\)\\)*\\]\\]"
+   "\\[\\[\\(\\([A-Za-z]+:\\)*[^]|]+\\)\\(|\\(\\([^]]+\\)\\)\\)*\\]\\]"
    (lambda (m)
      (apply
       'format
@@ -103,7 +103,7 @@ now, a size is supposed, and the values are assumed to be either
 a Width, or a WidthxHeight specification.
 "
   (replace-regexp-in-string
-   "{{\\([^?|]+\\)\\(\\?\\([^?|]+\\)\\)*\\(|\\([^}]+\\)\\)?}}"
+   "{{\\([^?|}]+\\)\\(\\?\\([^?|}]+\\)\\)*\\(|\\([^}]+\\)\\)?}}"
    (lambda (m)
      (apply
       'format

--- a/creole.el
+++ b/creole.el
@@ -156,7 +156,7 @@ appropriate HTML."
   (creole-image-parse
    (creole-link-parse
     (replace-regexp-in-string
-     "\\*\\*\\(\\(.\\|\n\\)*\\)\\*\\*"
+     "\\*\\*\\(\\(.\\|\n\\)*?\\)\\*\\*"
      "<strong>\\1</strong>"
      (replace-regexp-in-string
       "\\([^:]\\)//\\(\\(.\\|\n\\)*?[^:]\\)//"

--- a/creole.el
+++ b/creole.el
@@ -188,6 +188,10 @@ appropriate HTML."
                  (creole-block-parse "**//this is bold italic//**")))
   (should
    (equal
+    (creole-block-parse "**this is bold** this is not **but this is**")
+    "<strong>this is bold</strong> this is not <strong>but this is</strong>"))
+  (should
+   (equal
     (creole-block-parse "{{{this is code}}} and this is //italic//")
     "<code>this is code</code> and this is <em>italic</em>"))
   (should


### PR DESCRIPTION
Changed the regexp for strong font formatting, as these type of constructions:

**bold** non-bold **bold**

generated

<strong>bold non-bold bold</strong>

as the regext was eager.
