### PR TITLE
Added escaping for Oddmuse links. Fixes #25.

### DIFF
--- a/creole-tests.el
+++ b/creole-tests.el
@@ -41,6 +41,11 @@ broken over lines]]"))))
              (list link-thing)))
       (should (equal (creole-link-parse "ThisThing")
                      "<a href='ThisThing.creole'>ThisThing</a>"))
+      ;; make sure we do NOT escape if creole-oddmuse-on is nil
+      (should
+       (equal
+          (creole-link-parse "!OtherLongerThing")
+          "<a href='ThisThing.creole'>!OtherLongerThing</a>"))
       (let ((link-thing "OtherLongerThing.creole"))
         (should
          (equal
@@ -55,7 +60,11 @@ broken over lines]]"))))
           (should
            (equal
             (creole-link-parse "[OtherLongerThing]")
-            "<a href='OtherLongerThing.creole'>OtherLongerThing</a>")))))))
+            "<a href='OtherLongerThing.creole'>OtherLongerThing</a>"))
+          (should
+           (equal
+            (creole-link-parse "!UnescapedThing")
+            "UnescapedThing")))))))
 
 (ert-deftest creole-link-parse-resolver ()
   (let ((creole-link-resolver-fn 'creole/link-resolve))

--- a/creole.el
+++ b/creole.el
@@ -115,60 +115,63 @@ may as well resolve the extension in the webapp."
 (defun creole-link-parse (text)
   "Parse TEXT for creole links.
 
-If `creole-oddmuse-on' is t then OddMuse links will be parsed as
-well.  OddMuse links are single bracket links, like:
+If `creole-oddmuse-on' is t then OddMuse links (that do not start
+with '!') will be parsed as well. OddMuse links are single
+bracket links, like:
 
  [ThisIsOddMuse]
 
 If `creole-link-resolver-fn' is non-nil and a function then all
 single element links are passed through it.  This variable also
 turns on CamelCase linking."
-  (let* ((resolvable-link
-          (if (functionp creole-link-resolver-fn)
-              (let* ((case-fold-search nil)) ; do CamelCaps links
-                (replace-regexp-in-string
-                 (rx
-                  (or buffer-start bol bos)
-                  (group
-                   (? (not (any "[")))
-                   (group
-                    (>= 2 (and (any upper)
-                               (one-or-more (any lower)))))))
-                 (lambda (m)
-                   (let ((link (match-string 1 m)))
-                     (format
-                      "<a href='%s'>%s</a>"
-                      (funcall creole-link-resolver-fn link)
-                      link))) text t))
+  (if (and creole-oddmuse-on (string-match-p (rx bol "!") text))
+      (replace-regexp-in-string (rx bol "!") "" text t)
+    (let* ((resolvable-link
+            (if (functionp creole-link-resolver-fn)
+                (let* ((case-fold-search nil)) ; do CamelCaps links
+                  (replace-regexp-in-string
+                   (rx
+                    (or buffer-start bol bos)
+                    (group
+                     (? (not (any "[")))
+                     (group
+                      (>= 2 (and (any upper)
+                                 (one-or-more (any lower)))))))
+                   (lambda (m)
+                     (let ((link (match-string 1 m)))
+                       (format
+                        "<a href='%s'>%s</a>"
+                        (funcall creole-link-resolver-fn link)
+                        link))) text t))
               ;; Else just use the text
               text))
-         (real-creole
-          (replace-regexp-in-string
-           (rx "[["
-               (group
-                (* (group (or "ftp" "http" "mailto") ":"))
-                (+ (not (any "]|"))))
-               (*
-                (group
-                 "|" (group (group (+ (not (any "]")))))))
-               "]]")
-           'creole/link-replacer
-           resolvable-link))
-         (oddmuse
-          (when creole-oddmuse-on
+           (real-creole
             (replace-regexp-in-string
-             (rx "["
+             (rx "[["
                  (group
-                  (* (group (and (+ (in alpha))) ":"))
-                  (+ (not (any "]| "))))
-                 (* (group
-                     (any "| ")
-                     (group (group (+ (not (any ?\])))))))
-                 "]")
+                  (* (group (or "ftp" "http" "mailto") ":"))
+                  (+ (not (any "]|"))))
+                 (*
+                  (group
+                   "|" (group (group (+ (not (any "]")))))))
+                 "]]")
              'creole/link-replacer
-             real-creole)))
-         (bracket-resolved (if oddmuse oddmuse real-creole)))
-    bracket-resolved))
+             resolvable-link))
+           (oddmuse
+            (when creole-oddmuse-on
+              (replace-regexp-in-string
+               (rx "["
+                   (group
+                    (* (group (and (+ (in alpha))) ":"))
+                    (+ (not (any "]| "))))
+                   (* (group
+                       (any "| ")
+                       (group (group (+ (not (any ?\])))))))
+                   "]")
+               'creole/link-replacer
+               real-creole)))
+           (bracket-resolved (if oddmuse oddmuse real-creole)))
+      bracket-resolved)))
 
 (defvar creole-image-class nil
   "A default class to be applied to wiki linked images.")


### PR DESCRIPTION
This ended up being a simple change. Let me know if this is what you were expecting. Adds two more "should" tests in creole-link-parse-camel, too.
